### PR TITLE
remove volunteer_type

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,9 +2,6 @@ class Admin::UsersController < AdminController
   def index
     @filterrific = initialize_filterrific(User,
                                           params[:filterrific],
-                                          select_options: {
-                                            filter_volunteer_type: volunteer_type_options
-                                          },
                                           persistence_id: false)
 
     @filterrific_role = initialize_filterrific(User,
@@ -61,12 +58,6 @@ class Admin::UsersController < AdminController
 
   private
 
-  def volunteer_type_options
-    User.volunteer_types.keys.map do |volunteer_type|
-      [volunteer_type.humanize, volunteer_type]
-    end
-  end
-
   def role_options
     User.roles.keys.map do |role_type|
       [role_type.humanize, role_type]
@@ -83,7 +74,6 @@ class Admin::UsersController < AdminController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :role,
       :pledge_signed,
       :signed_guidelines,
@@ -99,17 +89,15 @@ class Admin::UsersController < AdminController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :pledge_signed,
       :signed_guidelines,
       :attended_training,
-      :remote_clinic_lawyer
+      :remote_clinic_lawyer,
+      language_ids: [],
     )
   end
 
   def user_index_scope
-    scope = current_community.users
-    scope = scope.for_volunteer_type(params[:volunteer_type]) if params[:volunteer_type].present?
-    scope
+    current_community.users
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -38,7 +38,6 @@ class InvitationsController < Devise::InvitationsController
                   :password_confirmation,
                   :remote_clinic_lawyer,
                   :invitation_token,
-                  :volunteer_type,
                   :pledge_signed,
                   language_ids: [])
     end

--- a/app/controllers/regional_admin/remote_lawyers_controller.rb
+++ b/app/controllers/regional_admin/remote_lawyers_controller.rb
@@ -55,12 +55,12 @@ class RegionalAdmin::RemoteLawyersController < AdminController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :role,
       :pledge_signed,
       :signed_guidelines,
       :remote_clinic_lawyer,
-      friend_ids: []
+      friend_ids: [],
+      language_ids: []
     )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,6 @@ class UsersController < ApplicationController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :pledge_signed,
       :remote_clinic_lawyer,
       language_ids: [],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,6 @@ class User < ApplicationRecord
   attr_reader :raw_invitation_token
 
   enum role: %i[volunteer accompaniment_leader admin data_entry]
-  enum volunteer_type: %i[english_speaking spanish_interpreter lawyer]
 
   validates :first_name, :last_name, :email, :phone, :community_id, presence: true
   validates :email, uniqueness: true
@@ -33,7 +32,7 @@ class User < ApplicationRecord
   has_many :reviews
   has_many :user_event_attendances, dependent: :destroy
 
- 
+
 
 
   accepts_nested_attributes_for :user_friend_associations, allow_destroy: true
@@ -45,7 +44,6 @@ class User < ApplicationRecord
       filter_first_name
       filter_last_name
       filter_email
-      filter_volunteer_type
       filter_role
     ]
   )
@@ -53,10 +51,6 @@ class User < ApplicationRecord
   def remote_clinic_friends
     friends.where(user_friend_associations: { remote: true })
   end
-
-  scope :filter_volunteer_type, ->(volunteer_type) {
-    where(volunteer_type: volunteer_type)
-  }
 
   scope :filter_role, ->(role) {
     where(role: role)

--- a/app/views/admin/users/_list.html.erb
+++ b/app/views/admin/users/_list.html.erb
@@ -11,8 +11,7 @@
         <th>Last Name</th>
         <th>Email</th>
         <th>Phone Number</th>
-        <th>Volunteer Type</th>
-        <th>Admin?</th>
+        <th>Role</th>
         <th>Created At</th>
         <th>Actions</th>
       </tr>
@@ -25,8 +24,7 @@
           <td><%= user.last_name %></td>
           <td><%= user.email %></td>
           <td><%= user.phone %></td>
-          <td><%= user.volunteer_type.try(:titleize) %></td>
-          <td><%= user.admin? ? 'YES' : 'NO' %></td>
+          <td><%= user.role.try(:titlecase) %></td>
           <td><%= user.created_at.strftime('%m/%d/%y') %></td>
           <td>
             <div class='btn-group'>

--- a/app/views/regional_admin/remote_lawyers/index.html.erb
+++ b/app/views/regional_admin/remote_lawyers/index.html.erb
@@ -8,8 +8,7 @@
         <th>Last Name</th>
         <th>Email</th>
         <th>Phone Number</th>
-        <th>Type</th>
-        <th>Admin?</th>
+        <th>Role</th>
         <th>Created</th>
         <th>Actions</th>
       </tr>
@@ -22,8 +21,7 @@
           <td><%= lawyer.last_name %></td>
           <td><%= lawyer.email %></td>
           <td><%= lawyer.phone %></td>
-          <td><%= lawyer.volunteer_type.try(:titleize) %></td>
-          <td><%= lawyer.admin? ? 'YES' : 'NO' %></td>
+          <td><%= lawyer.role.try(:titlecase) %></td>
           <td><%= lawyer.created_at.strftime('%m/%d/%y') %></td>
 
           <td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,51 +33,51 @@ ActiveRecord::Base.transaction do
                                   primary: true)
 
   # NY Regional admin
-  ny_regional_admin = User.create!(first_name: 'NY Regional', last_name: 'Admin', email: 'ny_regional_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  ny_regional_admin = User.create!(first_name: 'NY Regional', last_name: 'Admin', email: 'ny_regional_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 2, pledge_signed: true)
   ny_regional_admin.user_regions.create!(region_id: ny_region.id)
 
   ## NYC Users
 
   #Accompaniment Leader User
-  User.create!(first_name: 'NYC Accompaniment', last_name: 'Leader', email: 'nyc_accompaniment_leader@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
+  User.create!(first_name: 'NYC Accompaniment', last_name: 'Leader', email: 'nyc_accompaniment_leader@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 1, pledge_signed: true)
 
   #Volunteer User
-  User.create!(first_name: 'NYC Community', last_name: 'Volunteer', email: 'nyc_volunteer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+  User.create!(first_name: 'NYC Community', last_name: 'Volunteer', email: 'nyc_volunteer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
 
   #Admin User
-  User.create!(first_name: 'NYC Community', last_name: 'Admin', email: 'nyc_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  User.create!(first_name: 'NYC Community', last_name: 'Admin', email: 'nyc_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 2, pledge_signed: true)
 
   #Remote Clinic Lawyer
-  User.create!(first_name: 'Remote Clinic', last_name: 'Lawyer', email: 'remote_clinic_lawyer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: true)
+  User.create!(first_name: 'Remote Clinic', last_name: 'Lawyer', email: 'remote_clinic_lawyer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true, remote_clinic_lawyer: true)
 
   #Some additional NYC volunteer users
   20.times do |index|
     Timecop.travel(index.days.ago)
-    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
   end
   Timecop.return
 
   10.times do |index|
     Timecop.travel(index.days.ago)
-    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: false)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true, remote_clinic_lawyer: false)
   end
   Timecop.return
   ## Long Island Users
 
   #Accompaniment Leader User
-  User.create!(first_name: 'LI Accompaniment', last_name: 'Leader', email: 'li_accompaniment_leader@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
+  User.create!(first_name: 'LI Accompaniment', last_name: 'Leader', email: 'li_accompaniment_leader@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 1, pledge_signed: true)
 
   #Volunteer User
-  User.create!(first_name: 'LI Community', last_name: 'Volunteer', email: 'li_volunteer@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+  User.create!(first_name: 'LI Community', last_name: 'Volunteer', email: 'li_volunteer@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
 
   #Admin User
-  User.create!(first_name: 'LI Community', last_name: 'Admin', email: 'li_admin@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  User.create!(first_name: 'LI Community', last_name: 'Admin', email: 'li_admin@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 2, pledge_signed: true)
 
 
   #Some additional Long Island volunteer users
   30.times do |index|
     Timecop.travel(index.days.ago)
-    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: long_island_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: long_island_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
   end
   Timecop.return
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     email { Faker::Internet.unique.safe_email }
     phone { Faker::PhoneNumber.phone_number }
-    volunteer_type { 1 }
     password { (Faker::Food.fruits + Faker::PhoneNumber.area_code.to_s + Faker::Food.spice).delete(' ') }
     password_confirmation { password }
     invitation_accepted_at { Time.now }
@@ -40,7 +39,6 @@ FactoryBot.define do
     last_name { nil }
     email { Faker::Internet.unique.safe_email }
     phone { nil }
-    volunteer_type { nil }
     password { nil }
     password_confirmation { nil }
     invitation_accepted_at { nil }

--- a/spec/features/invite_a_new_user_spec.rb
+++ b/spec/features/invite_a_new_user_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe 'Admin invites a new user', type: :feature do
         fill_in 'First Name', with: Faker::Name.first_name
         fill_in 'Last Name', with: Faker::Name.last_name
         fill_in 'Phone', with: '876 765 4455'
-        select 'English Speaking', :from => 'Type'
         fill_in 'Password', with: 'Password1234'
         fill_in 'Password Confirmation', with: 'Password1234'
         check 'user_pledge_signed'

--- a/spec/models/mailers/review_mailer_spec.rb
+++ b/spec/models/mailers/review_mailer_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe ReviewMailer, type: :mailer do
 
   describe 'review_needed_email(draft)' do
     let(:draft) { create :draft, status: :in_review }
-    let(:user) { create :user, volunteer_type: "lawyer" }
-    let(:non_remote_clinic_user) { create :user, volunteer_type: "spanish_interpreter",
-                                          role: "volunteer" }
+    let(:user) { create :user }
+    let(:non_remote_clinic_user) { create :user, role: "volunteer" }
 
 
     subject(:mail) { ReviewMailer.review_needed_email(draft)}
@@ -41,10 +40,8 @@ RSpec.describe ReviewMailer, type: :mailer do
 
   describe 'lawyer_assignment_needed_email(draft)' do
     let(:draft) { create :draft, status: :in_review }
-    let(:admin_user) { create :user, volunteer_type: "spanish_interpreter",
-                                     role: "admin" }
-    let(:non_admin_user) { create :user, volunteer_type: "spanish_interpreter",
-                                         role: "volunteer" }
+    let(:admin_user) { create :user, role: "admin" }
+    let(:non_admin_user) { create :user, role: "volunteer" }
 
     subject(:mail) { ReviewMailer.lawyer_assignment_needed_email(draft)}
 
@@ -83,7 +80,7 @@ RSpec.describe ReviewMailer, type: :mailer do
     let(:draft) { create :draft, status: :changes_requested, friend: friend }
     let(:review) { create :review, draft: draft }
     let(:friend) { create :friend, community: community, region: region }
-    let!(:volunteer) { create :user, volunteer_type: 'english_speaking', community: community }
+    let!(:volunteer) { create :user, community: community }
     let!(:community_admin) { create :user, :community_admin, community: community }
     let!(:regional_admin) { create :user, :regional_admin, community: community }
 
@@ -119,7 +116,7 @@ RSpec.describe ReviewMailer, type: :mailer do
     let(:region) { community.region }
     let(:application) { create :application, friend: friend }
     let(:friend) { create :friend, community: community, region: region }
-    let!(:volunteer) { create :user, volunteer_type: 'english_speaking', community: community }
+    let!(:volunteer) { create :user, community: community }
     let!(:community_admin) { create :user, :community_admin, community: community }
     let!(:regional_admin) { create :user, :regional_admin, community: community }
 

--- a/spec/services/notifications_spec.rb
+++ b/spec/services/notifications_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Notification do
   describe '.draft_for_review(draft: draft)' do
     context 'the friend has a lawyer' do
       let(:draft) { create :draft, status: :in_review }
-      let(:user) { create :user, volunteer_type: "lawyer" }
+      let(:user) { create :user }
 
 
       context 'the friend has a remote lawyer' do


### PR DESCRIPTION
## Why is this PR needed?
A bit of additional cleanup around removing 'volunteer_types'.  volunteer_type is in a bunch of places, and I didn't cover all of them in the github issue, so just doing a quick pass to remove all references.  I realize, also, that my note about the deprecation of volunteer_type was kind of ambiguous, my goal is to remove all references in the codebase and functionality that depends on 'volunteer_type', but keep the database column.
